### PR TITLE
added 'memorystats' command, fixed 'move' command

### DIFF
--- a/lib/sched/scheduler.cpp
+++ b/lib/sched/scheduler.cpp
@@ -201,7 +201,7 @@ void CScheduler::PopTask()
 {
 	// DO NOT UNCOMMENT THIS UNLESS YOU KNOW WHAT YOU'RE DOING
 	// POPPING THE TASK AT [0] KILLS THE SYSTEM, FORCING MANUAL RESTART
-	
+
 	// m_pTask[0] = 0;
 	
 	// if (m_nTasks > 0)
@@ -335,7 +335,8 @@ CString CScheduler::listTasks()
 	_temp.Format("Current Task Index: %i || Task Count: %i || Total Possible Tasks: %i\n\n", m_nCurrent, m_nTasks, MAX_TASKS);
 	Message.Append((const char*) _temp);
 
-	int i, tempWeight;
+	unsigned int i;
+	int tempWeight;
 	// Using m_nTasks here prevents a stack overflow and kernel panic so be nice!
 	for (i = 0; i < m_nTasks; i++)
 	{
@@ -359,7 +360,8 @@ CString CScheduler::listTasks()
 // This one uses the logger to get it done
 void CScheduler::ListTasks()
 {
-	int i, tempWeight;
+	unsigned int i;
+	int tempWeight;
 
 	CLogger::Get()->Write(FromScheduler, LogNotice, "Current Task Index: %i || Task Count: %i || Total Possible Tasks: %i\n", m_nCurrent, m_nTasks, MAX_TASKS);
 

--- a/lib/screen.cpp
+++ b/lib/screen.cpp
@@ -302,22 +302,26 @@ void CScreenDevice::Write (char chChar)
 			break;
 
 		case 'A':
-			CursorUp ();
+			// Disable Up Arrow Key
+			// CursorUp ();
 			m_nState = ScreenStateStart;
 			break;
 
 		case 'B':
-			CursorDown ();
+			// Disable Down Arrow Key
+			// CursorDown ();
 			m_nState = ScreenStateStart;
 			break;
 
 		case 'C':
-			CursorRight ();
+			// Disable Right Arrow Key
+			// CursorRight ();
 			m_nState = ScreenStateStart;
 			break;
 
 		case 'D':
-			CursorLeft ();
+			// Disable Left Arrow Key
+			// CursorLeft ();
 			m_nState = ScreenStateStart;
 			break;
 

--- a/sample/00-pegasos/kernel.cpp
+++ b/sample/00-pegasos/kernel.cpp
@@ -319,7 +319,8 @@ void CKernel::commenceLogin()
 			strcat(userDirectory, _inputUsername);
 			strcat(userDirectory, "/desktop");
 
-			FRESULT _desktop = f_mkdir(userDirectory);
+			// FRESULT _desktop = f_mkdir(userDirectory);
+			f_mkdir(userDirectory);
 			FRESULT _Result = f_chdir(userDirectory);
 			if (_Result != FR_OK)
 			{


### PR DESCRIPTION
'memorystats' command displays all available heap space and total memory blocks
'move' now properly copies file data to new location
'login' command no longer prints "We found login!"
fixed code to remove warnings
disabled arrow keys in shell/screen